### PR TITLE
自動更新機能の実装

### DIFF
--- a/app/assets/javascripts/messages.js
+++ b/app/assets/javascripts/messages.js
@@ -2,7 +2,7 @@ $(function(){
   function buildHTML(message){
    var content = message.content ? `${message.content}` : "";
     var img = message.image ? `<img src="${message.image}">` : "";
-    var html = `<div class="message" data-id="${message.id}">
+    var html = `<div class="message" data-message-id="${message.id}">
                   <div class="message__upper-info">
                     <p class="message__upper-info__talker">
                       ${message.user_name}
@@ -47,4 +47,30 @@ $(function(){
       $('.form__submit').prop('disabled', false);
     })
   })
+  var reloadMessages = function() {
+    last_message_id = $(".message:last").data("message-id");
+    $.ajax({
+      url: 'api/messages',
+      type: 'get',
+      dataType: 'json',
+      data: {id: last_message_id}
+    })
+    .done(function(messages) {
+      messages.forEach(function(message){
+      var html = buildHTML(message);
+      $('.messages').append(html);
+      $('.messages').animate({
+      scrollTop: $('.messages')[0].scrollHeight
+      }, 300, "swing");
+    })
+  })
+    .fail(function() {
+      alert('エラーが発生したためメッセージは更新できませんでした。');;
+    });
+  };
+  $(window).on("load", function(){
+    if(document.URL.match("messages")){
+      setInterval(reloadMessages, 5000);
+    }
+  });
 });

--- a/app/controllers/api/messages_controller.rb
+++ b/app/controllers/api/messages_controller.rb
@@ -1,0 +1,7 @@
+class Api::MessagesController < ApplicationController
+  def index
+     group = Group.find(params[:group_id])
+     last_message_id = params[:id].to_i
+     @messages = group.messages.includes(:user).where("id > #{last_message_id}")
+   end
+end

--- a/app/views/api/messages/index.json.jbuilder
+++ b/app/views/api/messages/index.json.jbuilder
@@ -1,0 +1,7 @@
+json.array! @messages do |message|
+  json.content message.content
+  json.image message.image.url
+  json.created_at message.created_at
+  json.user_name message.user.name
+  json.id message.id
+end

--- a/app/views/api/messages/index.json.jbuilder
+++ b/app/views/api/messages/index.json.jbuilder
@@ -1,7 +1,7 @@
 json.array! @messages do |message|
   json.content message.content
   json.image message.image.url
-  json.created_at message.created_at
+  json.date message.created_at.strftime("%Y/%m/%d %H:%M")
   json.user_name message.user.name
   json.id message.id
 end

--- a/app/views/messages/_message.html.haml
+++ b/app/views/messages/_message.html.haml
@@ -1,4 +1,4 @@
-.message
+.message{ data: { message_id: message.id } }
    .message__upper-info
       %p.message__upper-info__talker
          = message.user.name

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -3,8 +3,3 @@ json.content @message.content
 json.date    @message.created_at.strftime("%Y/%m/%d %H:%M")
 json.user_name @message.user.name
 json.image   @message.image.url
-# json.(@message, :content, :image)
-# json.created_at @message.created_at
-# json.user_name @message.user.name
-# #idもデータとして渡す
-# json.id @message.id

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -3,3 +3,8 @@ json.content @message.content
 json.date    @message.created_at.strftime("%Y/%m/%d %H:%M")
 json.user_name @message.user.name
 json.image   @message.image.url
+# json.(@message, :content, :image)
+# json.created_at @message.created_at
+# json.user_name @message.user.name
+# #idもデータとして渡す
+# json.id @message.id

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,5 +4,8 @@ Rails.application.routes.draw do
   resources :users, only:[:index, :edit, :update]
   resources :groups, only: [:index, :new, :create, :edit, :update] do
     resources :messages, only: [:index, :create]
+    namespace :api do
+      resources :messages, only: :index, defaults: { format: 'json' }
+    end
   end
 end


### PR DESCRIPTION
# what
 - 数秒おきに自動で、ブラウザに表示されているメッセージのうち最新のメッセージのidをサーバにリクエスト
 - サーバ側ではそれよりも後に投稿されたメッセージのみを取得してレスポンス
 - クライアント側のJavaScriptで加工、メッセージ一覧に追加

# why
 - メッセージ画面が自動で更新されることで、自分以外のユーザーが送信したメッセージも更新時に表示されるようにするため

# check list
- [x] 表示されているメッセージのHTMLにid情報を追加
- [x] メッセージを更新するためのアクションを実装
- [x] 追加したアクションを動かすためのルーティングを実装
- [x] 追加したアクションをリクエストするよう実装
- [x] 取得した最新のメッセージをブラウザのメッセージ一覧に追加
- [x] 数秒ごとにリクエストするよう実装
- [x] メッセージ分だけスクロールするよう実装
- [x] メッセージ一覧のページでのみJSが動くよう実装

# action
https://gyazo.com/89896c3e13bf4f515bc0a9f9a23ac33f